### PR TITLE
chore(REACH2-756): fix a parser for dfxp files

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export interface CaptionItem extends Cuepoint {
 export const toSeconds = (val: any, vtt = false): number => {
     const regex = vtt
         ? /(\d+):(\d{2}):(\d{2}).(\d{2,3}|\d{2})/
-        : /(\d+):(\d{2}):(\d{2}),(\d{2,3}|\d{2})/;
+        : /(\d+):(\d{2}):(\d{2})(,(\d{2,3}|\d{2}|\d{1}))?/;
     const parts: any | null[] = regex.exec(val);
     if (parts === null) {
         return 0;


### PR DESCRIPTION
change a regex for parsing dfxp files
supported captions time formats:
xx:xx:xx,xxx
xx:xx:xx,xx
xx:xx:xx,x
xx:xx:xx