### PR TITLE
chore(REACH2-743) - filter captions by lang, label and index

### DIFF
--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -36,8 +36,7 @@ import {
   isBoolean,
   makePlainText,
   CaptionAssetServeAction,
-  deepGet,
-  isString
+  deepGet
 } from "./utils";
 import { DownloadPrintMenu } from "./components/download-print-menu";
 
@@ -257,9 +256,9 @@ export class TranscriptPlugin implements OnMediaLoad, OnMediaUnload, OnPluginSet
   }
 
   private _findCaptionAsset = (
-      event: any
+      event: string | {}
   ): KalturaCaptionAsset => {
-    if (isString(event)) {
+    if (typeof event === 'string') {
       const filteredByLang = this._filterCaptionAssetsByProperty(this._captionsList, event, 'languageCode');
       // take first captions from caption-list when caption language is not defined
       return filteredByLang[0] ? filteredByLang[0] : this._captionsList[0];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,7 +173,7 @@ export class CaptionAssetServeAction extends KalturaRequest<{url: string}> {
     }
   }
 
-  export function deepGet(obj: any, props: Array<string>, defaultValue: any): any {
+  export function deepGet(obj: any, props: Array<string>, defaultValue?: any): any {
     // If we have reached an undefined/null property
     // then stop executing and return the default value.
     // If no default was provided it will be undefined.
@@ -193,3 +193,7 @@ export class CaptionAssetServeAction extends KalturaRequest<{url: string}> {
 
     return deepGet(foundSoFar, remainingProps, defaultValue);
 }
+
+export function isString(val: any) {
+    return typeof val == 'string';
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -194,6 +194,3 @@ export class CaptionAssetServeAction extends KalturaRequest<{url: string}> {
     return deepGet(foundSoFar, remainingProps, defaultValue);
 }
 
-export function isString(val: any) {
-    return typeof val == 'string';
-};


### PR DESCRIPTION
1. filter captions by language
2. in case if first filter returns more than 1 caption - make a filter by label
3. in case if second filter returns more than 1 caption - make a filter by index
4. in case if any filters doesn’t return anything - use first caption from caption list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/playkit-js-transcript/37)
<!-- Reviewable:end -->
