### PR TITLE
chore(REACH2-789): style fix when captions without time

### DIFF
--- a/src/components/Caption/Caption.tsx
+++ b/src/components/Caption/Caption.tsx
@@ -120,7 +120,7 @@ export class Caption extends Component<ExtendedCaptionProps> {
                 )}
                 <div
                     onClick={this._handleClick}
-                    className={`${styles.captionContent} ${highlighted ? styles.highlighted : ""}`}
+                    className={`${styles.captionContent} ${highlighted ? styles.highlighted : ""} ${showTime ? "" : styles.withoutTime}`}
                     type="button"
                     ref={node => {
                         this._hotspotRef = node;

--- a/src/components/Caption/caption.scss
+++ b/src/components/Caption/caption.scss
@@ -41,6 +41,9 @@
         padding: 0 2px;
       }
     }
+    &.without-time {
+      margin-left: 16px;
+    }
     .caption-span {
       user-select: text;
       border-radius: 2px;


### PR DESCRIPTION
- added margin when time disabled
<img width="778" alt="Screen Shot 2020-02-06 at 2 40 39 PM" src="https://user-images.githubusercontent.com/51074448/73937921-cc95b100-48ee-11ea-82ca-2f9958c82467.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/playkit-js-transcript/39)
<!-- Reviewable:end -->
