### PR TITLE
chore(REACH2-788): fix style for text selection in IE

### DIFF
--- a/src/components/Caption/caption.scss
+++ b/src/components/Caption/caption.scss
@@ -46,6 +46,7 @@
     }
     .caption-span {
       user-select: text;
+      -ms-user-select: text;
       border-radius: 2px;
       cursor: pointer;
       &::selection {


### PR DESCRIPTION
- added MS flag to css for text-selection in IE11 and Edge
<img width="599" alt="Screen Shot 2020-02-11 at 11 14 59 AM" src="https://user-images.githubusercontent.com/51074448/74223660-e0ab2b00-4cbf-11ea-92a9-2ba00797a0e6.png">
