### PR TITLE
chore(REACH2-816) - search component styles

### DIFF
--- a/src/components/Search/search.scss
+++ b/src/components/Search/search.scss
@@ -37,9 +37,9 @@
     flex-direction: column;
     justify-content: space-around;
     height: 100%;
-    margin-right: 2px;
+    margin-right: 8px;
     .prev-next-button {
-      width: 9px;
+      width: 14px;
       height: 6px;
       background-color: transparent;
       background-position: center;

--- a/src/components/Search/search.tsx
+++ b/src/components/Search/search.tsx
@@ -83,13 +83,13 @@ export class Search extends Component<SearchProps, SearchState> {
                 />
                 {value && <button className={styles.clearIcon} onClick={this._onClear} />}
                 {value && (
-                    <p className={styles.searchResults}>
+                    <div className={styles.searchResults}>
                         {`${
                             totalSearchResults > 0
                                 ? `${activeSearchIndex}/${totalSearchResults}`
                                 : "0/0"
                         }`}
-                    </p>
+                    </div>
                 )}
                 <div className={styles.prevNextWrapper}>
                     {value && (


### PR DESCRIPTION
Issue happened because host page has styles for <p> tag with stronger selector than TW styles.
As a temporary solution <p> tag changed to <div>
Final solution - using 'normalize.css' for resetting all external styles for TW.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/playkit-js-transcript/51)
<!-- Reviewable:end -->
