### PR TITLE
fix(REACH2-1004): use player enums to define plugin expand mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,25 @@
 ## Project structure
 > this section will be added soon
 
-## Commands
-> this section will be added soon
+## Plugin configuration
+
+### Plugin configuration can be defined as object of properties, ex: 
+```
+            'playkit-js-transcript': {
+                position: 'right',
+                printDisabled : true,
+                expandMode:'over'
+            }
+```
+
+### List of available configuration properties:
+Parameter | Description | Type | Default 
+--- | --- | :-----: | :-----:
+expandMode | Set player area for TW | `"alongside" | "over"` | `"alongside"`
+expandOnFirstPlay | Opens plugin on automatically | `boolean` | `true`
+showTime | Show or hide caption time | `boolean` | `true`
+position | Position of TW plugin | `"right" | "bottom"` | `"bottom"`
+searchDebounceTimeout | Debounce on caption search | `number` | `250`
+searchNextPrevDebounceTimeout | Debounce on jump to prev\next search result | `number` | `100`
+downloadDisabled | Disable download of transcript | `boolean` | `false`
+printDisabled | Disable print of transcript | `boolean` | `false`

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -40,7 +40,6 @@ import {
   isBoolean,
   makePlainText,
   CaptionAssetServeAction,
-  parseExpandMode
 } from "./utils";
 import { DownloadPrintMenu } from "./components/download-print-menu";
 
@@ -169,7 +168,9 @@ export class TranscriptPlugin implements OnMediaLoad, OnPluginSetup, OnMediaUnlo
     const { expandMode, position, expandOnFirstPlay } = this._configs.pluginConfig;
     this._kitchenSinkItem = this._contribServices.kitchenSinkManager.add({
       label: "Transcript",
-      expandMode: parseExpandMode(expandMode),
+      expandMode: expandMode === KitchenSinkExpandModes.OverTheVideo ?
+        KitchenSinkExpandModes.OverTheVideo :
+        KitchenSinkExpandModes.AlongSideTheVideo,
       renderIcon: () => (
         <button
           className={styles.pluginButton}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,24 +2,12 @@ import { xml2js } from "xml-js";
 import { Cuepoint } from "@playkit-js-contrib/common";
 import { KalturaRequest, KalturaRequestArgs } from 'kaltura-typescript-client/api/kaltura-request';
 import { KalturaObjectMetadata } from 'kaltura-typescript-client/api/kaltura-object-base';
-import {KitchenSinkExpandModes} from '@playkit-js-contrib/ui/';
 
 export const HOUR = 3600; // seconds in 1 hour
 
 export interface CaptionItem extends Cuepoint {
     text: string;
     id: number;
-}
-
-
-// TODO: consider move to contrib
-export const parseExpandMode = (value: string): KitchenSinkExpandModes => {
-  switch (value) {
-    case KitchenSinkExpandModes.OverTheVideo:
-        return KitchenSinkExpandModes.OverTheVideo;
-    default:
-        return KitchenSinkExpandModes.AlongSideTheVideo;
-  }
 }
 
 export const toSeconds = (val: any, vtt = false): number => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,10 +15,10 @@ export interface CaptionItem extends Cuepoint {
 // TODO: consider move to contrib
 export const parseExpandMode = (value: string): KitchenSinkExpandModes => {
   switch (value) {
-    case "AlongSideTheVideo":
-      return KitchenSinkExpandModes.AlongSideTheVideo;
+    case KitchenSinkExpandModes.OverTheVideo:
+        return KitchenSinkExpandModes.OverTheVideo;
     default:
-      return KitchenSinkExpandModes.OverTheVideo;
+        return KitchenSinkExpandModes.AlongSideTheVideo;
   }
 }
 


### PR DESCRIPTION
- use player enums to define expand mode of plugin;
- add to README plugin configuration