### PR TITLE
fix(FEV-1362): When starting a video with captions language off, there is no transcript shown. after choosing a specific caption language still nothing shown in the transcript.

### DIFF
--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -1,5 +1,5 @@
 import {h, Component} from 'preact';
-import {A11yWrapper} from '@playkit-js/common';
+import {A11yWrapper, OnClickEvent} from '@playkit-js/common';
 import {debounce} from '../../utils';
 import * as styles from './transcript.scss';
 import {Spinner} from '../spinner';
@@ -84,7 +84,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
     this._setWidgetSize();
   }
 
-  private _enableAutoScroll = (event: any, byKeyboard?: boolean) => {
+  private _enableAutoScroll = (event: OnClickEvent, byKeyboard?: boolean) => {
     event.preventDefault();
     if (this.state.isAutoScrollEnabled) {
       return;
@@ -93,7 +93,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
     this.setState({
       isAutoScrollEnabled: true
     });
-    if (event.type !== 'click') {
+    if (byKeyboard) {
       this._skipTranscriptButtonRef?.focus();
     }
   };

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -77,7 +77,11 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
   private _initListeners(): void {
     this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => {
       if ((this.player.getTracks(this.player.Track.TEXT) || []).length) {
-        this._isLoading = true;
+        // check if captions already added in TextTrack
+        if (!this._captionMap.size) {
+          // turn on loading animation till captions added to TextTrack
+          this._isLoading = true;
+        }
         this._addPopoverIcon();
         this._addTranscriptItem();
       }


### PR DESCRIPTION
resolve race condition between API call and FirstPlaying event