### PR TITLE
fix(FEV-1531): when transcript panel is open, navigating inside it using tab is not working properly

### DIFF
--- a/src/components/caption/caption.tsx
+++ b/src/components/caption/caption.tsx
@@ -116,8 +116,8 @@ export class Caption extends Component<ExtendedCaptionProps> {
       <A11yWrapper onClick={this._handleKeyDown}>
         <div
           className={styles.caption}
-          tabIndex={1}
-          area-label={caption.text}
+          tabIndex={0}
+          aria-label={caption.text}
           ref={node => {
             this._hotspotRef = node;
           }}

--- a/src/components/close-button/index.tsx
+++ b/src/components/close-button/index.tsx
@@ -16,7 +16,7 @@ interface CloseButtonProps {
 
 export const CloseButton = withText(translates)((props: CloseButtonProps) => (
   <A11yWrapper onClick={props.onClick}>
-    <button className={styles.closeBtn} tabIndex={1} aria-label={props.closeLabel}>
+    <button className={styles.closeBtn} tabIndex={0} aria-label={props.closeLabel}>
       <Icon
         id="transcript-plugin-close-button"
         height={icons.BigSize}

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -167,14 +167,14 @@ class SearchComponent extends Component<SearchProps, SearchState> {
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           onMouseDown={this._handleMouseDown}
-          tabIndex={1}
+          tabIndex={0}
           ref={node => {
             this._inputRef = node;
           }}
         />
         {searchQuery && (
           <A11yWrapper onClick={this._onClear}>
-            <button className={styles.clearIcon} tabIndex={1} aria-label={this.props.clearSearchLabel}>
+            <button className={styles.clearIcon} tabIndex={0} aria-label={this.props.clearSearchLabel}>
               <svg
                 width="32px"
                 height="32px"
@@ -201,7 +201,7 @@ class SearchComponent extends Component<SearchProps, SearchState> {
           {searchQuery && (
             <A11yWrapper onClick={this._goToPrevSearchResult}>
               <button
-                tabIndex={1}
+                tabIndex={0}
                 className={`${styles.prevNextButton} ${totalSearchResults === 0 ? styles.disabled : ''}`}
                 aria-label={this.props.prevMatchLabel}>
                 <svg
@@ -225,7 +225,7 @@ class SearchComponent extends Component<SearchProps, SearchState> {
           {searchQuery && (
             <A11yWrapper onClick={this._goToNextSearchResult}>
               <button
-                tabIndex={1}
+                tabIndex={0}
                 className={`${styles.prevNextButton} ${totalSearchResults === 0 ? styles.disabled : ''}`}
                 aria-label={this.props.nextMatchLabel}>
                 <svg

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -111,7 +111,7 @@ export class TranscriptComponent extends Component<TranscriptProps, TranscriptSt
         <div
           role="button"
           className={`${styles.autoscrollButton} ${isAutoScrollEnabled ? '' : styles.autoscrollButtonVisible}`}
-          tabIndex={isAutoScrollEnabled ? -1 : 1}
+          tabIndex={isAutoScrollEnabled ? -1 : 0}
           aria-label={this.props.autoScrollLabel}
           ref={node => {
             this._autoscrollButtonRef = node;
@@ -238,7 +238,7 @@ export class TranscriptComponent extends Component<TranscriptProps, TranscriptSt
         className={styles.skipTranscriptButton}
         onKeyDown={this._handleKeyDown}
         onClick={this._handleClick}
-        tabIndex={1}>
+        tabIndex={0}>
         Skip transcript
       </div>
     );


### PR DESCRIPTION
**the issue:**
when transcript panel is open, navigating inside it using tab is not working properly- it is possible to navigate inside the transcript panel only after elements outside the player have been touched.

**root cause:**
tab index of transcript's elements are set to 1. the browser first navigating throughout elements with tabindex=0.

**solution:**
change tabIndex to 0.

Solves [FEV-1531](https://kaltura.atlassian.net/browse/FEV-1531)