### PR TITLE
fix(FEV-1623): The transition animation is broken when the side panel is activated 

### DIFF
--- a/.github/workflows/common_test.yml
+++ b/.github/workflows/common_test.yml
@@ -1,0 +1,11 @@
+name: deploy to QA
+
+on:
+  pull_request:
+    types: 
+      - opened
+  
+jobs:
+   test:
+    uses: kaltura/playkit-js-common/.github/workflows/test.yml@master
+    secrets: inherit

--- a/.github/workflows/common_test.yml
+++ b/.github/workflows/common_test.yml
@@ -1,4 +1,4 @@
-name: deploy to QA
+name: Run tests
 
 on:
   pull_request:

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "html5 player"
   ],
   "dependencies": {
-    "@playkit-js/common": "^1.1.1",
+    "@playkit-js/common": "^1.1.2",
     "@playkit-js/playkit-js-ui": "^0.73.0",
     "@playkit-js/ui-managers": "^1.3.2",
     "cypress": "^12.3.0",

--- a/src/components/autoscroll-button/autoscroll-button.tsx
+++ b/src/components/autoscroll-button/autoscroll-button.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 import * as styles from './autoscroll-button.scss';
-import {A11yWrapper, OnClick} from '@playkit-js/common';
+import {A11yWrapper, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
 const {Tooltip} = KalturaPlayer.ui.components;

--- a/src/components/caption/caption.tsx
+++ b/src/components/caption/caption.tsx
@@ -1,5 +1,5 @@
 import {Component, h} from 'preact';
-import {A11yWrapper, OnClickEvent} from '@playkit-js/common';
+import {A11yWrapper, OnClickEvent} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {secontsToTime} from '../../utils';
 import {CuePointData} from '../../types';
 import * as styles from './caption.scss';

--- a/src/components/close-button/index.tsx
+++ b/src/components/close-button/index.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 import * as styles from './close-button.scss';
-import {A11yWrapper} from '@playkit-js/common';
+import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {icons} from '../icons';
 const {Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;

--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -2,7 +2,7 @@ import {h} from 'preact';
 import * as styles from './plugin-button.scss';
 import {ui} from 'kaltura-player-js';
 import {icons} from '../icons';
-import {A11yWrapper, OnClick} from '@playkit-js/common';
+import {A11yWrapper, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,5 +1,5 @@
 import {h, Component} from 'preact';
-import {InputField} from '@playkit-js/common';
+import {InputField} from '@playkit-js/common/dist/components/input-field';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
 const translates = ({activeSearchIndex, totalSearchResults}: SearchProps) => ({
@@ -54,7 +54,7 @@ class SearchComponent extends Component<SearchProps> {
   componentDidUpdate(previousProps: Readonly<SearchProps>): void {
     const {kitchenSinkActive, toggledWithEnter} = this.props;
     if (!previousProps.kitchenSinkActive && kitchenSinkActive && toggledWithEnter) {
-      this._inputField?.setFocus();
+      this._inputField?.setFocus({preventScroll: true});
     }
   }
 

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -1,5 +1,5 @@
 import {h, Component} from 'preact';
-import {OnClickEvent, OnClick} from '@playkit-js/common';
+import {OnClickEvent, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {debounce} from '../../utils';
 import * as styles from './transcript.scss';
 import {Spinner} from '../spinner';

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -1,5 +1,5 @@
 import {h} from 'preact';
-import {OnClickEvent} from '@playkit-js/common';
+import {OnClickEvent} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {ui} from 'kaltura-player-js';
 import {UpperBarManager, SidePanelsManager} from '@playkit-js/ui-managers';
 import {ObjectUtils, downloadContent, printContent} from './utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,10 +130,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@playkit-js/common@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.1.1.tgz#b0c21e96794dd66622c1bbcfdf0373aad2b9f5dc"
-  integrity sha512-75l2CogQtpLggXp/FxjNsPbV+FKZ1MxhhLJolBwJYsKV/tyd61aKcbU81EzcyyVefkxYEcLdt2YrkFW64isTKw==
+"@playkit-js/common@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.1.2.tgz#35e86126d87f9006795033bce7e3d9a1b885b61f"
+  integrity sha512-N/mcYl9sKpdRs56lUwNxdRZZtljQE35+K8XeY15d7Vcalnh5tWgcY4zqTYAqT3mz4wL1hY15fHe5rYuDF0WH1A==
   dependencies:
     "@playkit-js/playkit-js-ui" "^0.74.0"
     linkify-it "^4.0.1"


### PR DESCRIPTION
The transition animation is broken when the side panel is activated

solve [FEV-1623](https://kaltura.atlassian.net/browse/FEV-1623)

fix transition animation
import from @playkit-js/common only components that Navigation plugin uses
add test workflow to GH actions
dependent PR: https://github.com/kaltura/playkit-js-common/pull/10

[FEV-1623]: https://kaltura.atlassian.net/browse/FEV-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ