### PR TITLE
fix(FEC-12957): Transcript Plugin - move download transcript inside the plugin menu and "release" the download button.

### DIFF
--- a/src/components/popover-menu/popover-menu.scss
+++ b/src/components/popover-menu/popover-menu.scss
@@ -2,7 +2,6 @@
 
 .popover-anchor-container {
   cursor: pointer;
-  margin-left: 8px;
   border-radius: $roundness-1;
   
   &:hover {

--- a/src/components/popover-menu/popover-menu.scss
+++ b/src/components/popover-menu/popover-menu.scss
@@ -53,8 +53,12 @@
   padding: 9px 24px 9px 16px;
   white-space: nowrap;
   margin: 4px;
+
+  &.popover-menu-item-disabled {
+    color: $tone-4-color;
+  }
   
-  &:hover {
+  &:hover :not(.popover-menu-item-disabled) {
     background-color: $tone-6-color;
     border-radius: $roundness-1;
     cursor: pointer;

--- a/src/components/transcript-menu/transcript-menu.tsx
+++ b/src/components/transcript-menu/transcript-menu.tsx
@@ -12,6 +12,7 @@ interface TranscriptMenuProps {
   onPrint: () => void;
   downloadDisabled?: boolean;
   printDisabled?: boolean;
+  isLoading?: boolean;
 }
 
 interface TranscriptMenuState {
@@ -22,13 +23,14 @@ class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState>
   constructor(props: TranscriptMenuProps) {
     super();
 
-    const {downloadDisabled, onDownload, printDisabled, onPrint, printDownloadAreaLabel, printTranscript, downloadTranscript} = props;
+    const {downloadDisabled, onDownload, printDisabled, onPrint, printDownloadAreaLabel, printTranscript, downloadTranscript, isLoading} = props;
     const items = [];
     if (!downloadDisabled) {
       items.push({
         testId: 'download-menu-item',
         label: 'Download transcript',
-        onClick: onDownload
+        onClick: onDownload,
+        isDisabled: isLoading
       });
     }
 
@@ -36,7 +38,8 @@ class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState>
       items.push({
         testId: 'print-menu-item',
         label: 'Print transcript',
-        onClick: onPrint
+        onClick: onPrint,
+        isDisabled: isLoading
       });
     }
 

--- a/src/components/transcript-menu/transcript-menu.tsx
+++ b/src/components/transcript-menu/transcript-menu.tsx
@@ -15,7 +15,6 @@ interface TranscriptMenuProps {
 }
 
 interface TranscriptMenuState {
-  isOpen: boolean;
   items: Array<PopoverMenuItemData>;
 }
 
@@ -41,12 +40,12 @@ class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState>
       });
     }
 
-    this.state = {isOpen: false, items};
+    this.state = {items};
   }
 
   render() {
     return this.state.items.length ? (
-      <PopoverMenu items={this.state.items}>
+      <PopoverMenu label={'More'} items={this.state.items}>
         <Button type={ButtonType.borderless} icon={'more'}></Button>
       </PopoverMenu>
     ) : null;

--- a/src/components/transcript/transcript.scss
+++ b/src/components/transcript/transcript.scss
@@ -61,6 +61,7 @@
   padding-left: 16px;
   font-size: 16px;
   padding-right: 16px;
+  gap: 8px;
 }
 
 .body {

--- a/src/components/transcript/transcript.scss
+++ b/src/components/transcript/transcript.scss
@@ -62,6 +62,7 @@
   font-size: 16px;
   padding-right: 16px;
   gap: 8px;
+  z-index: 2;
 }
 
 .body {

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -203,6 +203,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
             size={ButtonSize.medium}
             disabled={false}
             onClick={this.props.onClose}
+            ariaLabel={'Hide Transcript'}
             tooltip={{label: 'Hide Transcript'}}
             icon={'close'}></Button>
         </div>

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -183,7 +183,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
   };
 
   private _renderHeader = () => {
-    const {toggledWithEnter, kitchenSinkActive, downloadDisabled, onDownload, printDisabled, onPrint} = this.props;
+    const {toggledWithEnter, kitchenSinkActive, downloadDisabled, onDownload, printDisabled, onPrint, isLoading} = this.props;
     const {search, activeSearchIndex, totalSearchResults} = this.state;
     return (
       <div className={[styles.header, this._getHeaderStyles()].join(' ')} data-testid="transcript_header">
@@ -196,7 +196,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
           toggledWithEnter={toggledWithEnter}
           kitchenSinkActive={kitchenSinkActive}
         />
-        <TranscriptMenu {...{downloadDisabled, onDownload, printDisabled, onPrint}} />
+        <TranscriptMenu {...{downloadDisabled, onDownload, printDisabled, onPrint, isLoading}} />
         <div data-testid="transcriptCloseButton">
           <Button
             type={ButtonType.borderless}


### PR DESCRIPTION
Fixes after version testing:
- Add margin between buttons
- Disable menu items while plugin is loading (e.g. on text track change)
- Add aria-label and tooltips
- Add tab and arrow navigation to menu items
- Close popover menu when using tab to navigate outside of it