### PR TITLE
fix(FEC-13281): The "More Transcript Options" button is not accessible only with keyboard presses

### DIFF
--- a/src/components/popover-menu/popover-menu.scss
+++ b/src/components/popover-menu/popover-menu.scss
@@ -58,7 +58,7 @@
     color: $tone-4-color;
   }
   
-  &:hover :not(.popover-menu-item-disabled) {
+  &:hover:not(.popover-menu-item-disabled) {
     background-color: $tone-6-color;
     border-radius: $roundness-1;
     cursor: pointer;

--- a/src/components/popover-menu/popover-menu.tsx
+++ b/src/components/popover-menu/popover-menu.tsx
@@ -107,7 +107,10 @@ class PopoverMenu extends Component<PopoverMenuProps, PopoverMenuState> {
 
     const popoverMenuContent = (
       <div className={styles.popoverContainer}>
-        <A11yWrapper onClick={() => this.togglePopover(true)}>
+        <A11yWrapper onClick={(e) => {
+          e.stopPropagation();
+          this.togglePopover(true);
+        }}>
           <div
             aria-label={this.props.moreOptionsLabel!}
             tabIndex={0}


### PR DESCRIPTION
`e.stopPropagation();` prevents `document` handle mouse click that closes popover menu.
<img width="407" alt="image" src="https://github.com/kaltura/playkit-js-transcript/assets/51074448/e88939b4-cba6-4c49-b158-64f457cbd729">
