### PR TITLE
fix(ADA-33): [V7-Acc] SVG icons need to be hidden from screen reader

### DIFF
--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -27,7 +27,7 @@ export const PluginButton = ({isActive, label, id, icon, dataTestId, setRef}: Pl
           aria-label={label}
           className={[ui.style.upperBarIcon, styles.pluginButton, isActive ? styles.active : ''].join(' ')}
           data-testid={dataTestId}>
-          <Icon id={id} height={icons.BigSize} width={icons.BigSize} viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`} path={icon} />
+          <Icon id={id} height={icons.BigSize} width={icons.BigSize} viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`} path={icon} hidden="true"/>
         </button>
     </Tooltip>
   );


### PR DESCRIPTION
Adding "aria-hidden" to show/hide icon.
related to https://github.com/kaltura/playkit-js-ui/pull/788

solves [ADA-33](https://kaltura.atlassian.net/browse/ADA-33)

[ADA-33]: https://kaltura.atlassian.net/browse/ADA-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ