### PR TITLE
fix(ADA-104): Button in the transcript does not have a programmatic name

### DIFF
--- a/src/components/autoscroll-button/autoscroll-button.tsx
+++ b/src/components/autoscroll-button/autoscroll-button.tsx
@@ -19,7 +19,7 @@ const translates = {
 export const AutoscrollButton = withText(translates)(
   ({onClick, isAutoScrollEnabled, setAutoscrollButtonRef, autoScrollLabel}: AutoscrollButtonProps) => {
     return (
-      <div className={styles.autoscrollRoot} tabIndex={isAutoScrollEnabled ? -1 : 1} aria-label={autoScrollLabel}>
+      <div className={styles.autoscrollRoot} tabIndex={isAutoScrollEnabled ? -1 : 1}>
         <Button
           onClick={onClick}
           setRef={setAutoscrollButtonRef}
@@ -27,6 +27,7 @@ export const AutoscrollButton = withText(translates)(
           type={ButtonType.primary}
           icon="autoScroll"
           tooltip={{label: autoScrollLabel!, type: 'left'}}
+          ariaLabel={autoScrollLabel}
         />
       </div>
     );


### PR DESCRIPTION
**issue:**
screen reader announce only "button" on autoScroll button

**solution:** 
move the aria-label from the wrapping element to the button element

solves [ADA-104](https://kaltura.atlassian.net/browse/ADA-104)

[ADA-104]: https://kaltura.atlassian.net/browse/ADA-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ