### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,6 @@ const NAME = __NAME__;
 export {TranscriptPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'playkit-js-transcript';
+export const pluginName: string = 'playkit-js-transcript';
 
 KalturaPlayer.core.registerPlugin(pluginName, TranscriptPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {TranscriptPlugin} from './transcript-plugin';
+import { pluginName, TranscriptPlugin } from "./transcript-plugin";
 
 declare var __VERSION__: string;
 declare var __NAME__: string;
@@ -8,7 +8,5 @@ const NAME = __NAME__;
 
 export {TranscriptPlugin as Plugin};
 export {VERSION, NAME};
-
-export const pluginName: string = 'playkit-js-transcript';
 
 KalturaPlayer.core.registerPlugin(pluginName, TranscriptPlugin);

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -275,6 +275,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
       // @ts-ignore
       displayName: 'Transcript',
       ariaLabel: 'Transcript',
+      order: 30,
       svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
       onClick: this._handleClickOnPluginIcon as () => void,
       component: withText(translates)((props: {showTranscript: string; hideTranscript: string}) => {

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -9,7 +9,8 @@ import {PluginButton} from './components/plugin-button/plugin-button';
 import {Transcript} from './components/transcript';
 import {getConfigValue, isBoolean, makePlainText, prepareCuePoint} from './utils';
 import {TranscriptConfig, PluginStates, HighlightedMap, CuePointData, ItemTypes, CuePoint} from './types';
-import { pluginName } from "./index";
+
+export const pluginName: string = 'playkit-js-transcript';
 
 const {SidePanelModes, SidePanelPositions, ReservedPresetNames, ReservedPresetAreas} = ui;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -9,6 +9,7 @@ import {PluginButton} from './components/plugin-button/plugin-button';
 import {Transcript} from './components/transcript';
 import {getConfigValue, isBoolean, makePlainText, prepareCuePoint} from './utils';
 import {TranscriptConfig, PluginStates, HighlightedMap, CuePointData, ItemTypes, CuePoint} from './types';
+import { pluginName } from "./index";
 
 const {SidePanelModes, SidePanelPositions, ReservedPresetNames, ReservedPresetAreas} = ui;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
@@ -267,8 +268,13 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
       showTranscript: <Text id="transcript.show_plugin">Show Transcript</Text>,
       hideTranscript: <Text id="transcript.hide_plugin">Hide Transcript</Text>
     };
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     this._transcriptIcon = this.upperBarManager!.add({
-      label: 'Transcript',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      displayName: 'Transcript',
+      ariaLabel: 'Transcript',
       svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
       onClick: this._handleClickOnPluginIcon as () => void,
       component: withText(translates)((props: {showTranscript: string; hideTranscript: string}) => {
@@ -277,7 +283,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
         return (
           <PluginButton
             isActive={isActive}
-            id="transcript-icon"
+            id={pluginName}
             label={label}
             icon={icons.PLUGIN_ICON}
             dataTestId="transcript_pluginButton"


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-info/pull/90
https://github.com/kaltura/playkit-js-downloads/pull/39
https://github.com/kaltura/playkit-js-qna/pull/334