### PR TITLE
fix(ADA-103): Transcript Options button doesn't announce “expanded” or “collapsed

### DIFF
--- a/src/components/popover-menu/popover-menu.tsx
+++ b/src/components/popover-menu/popover-menu.tsx
@@ -116,6 +116,8 @@ class PopoverMenu extends Component<PopoverMenuProps, PopoverMenuState> {
             tabIndex={0}
             data-testid="popover-anchor-container"
             className={`${styles.popoverAnchorContainer} ${this.state.isOpen ? styles.active : ''}`}
+            aria-expanded={this.state.isOpen}
+            aria-controls="popoverContent"
             ref={node => {
               this._controlElementRef = node;
             }}>
@@ -127,6 +129,7 @@ class PopoverMenu extends Component<PopoverMenuProps, PopoverMenuState> {
           className={styles.popoverComponent}
           role="menu"
           aria-expanded={this.state.isOpen}
+          id="popoverContent"
           ref={node => {
             this._popoverElementRef = node;
           }}>


### PR DESCRIPTION
**Issue:**
More transcript option button doesn't announce  its state “expanded” or “collapsed”. 

**Fix:**
Add aria-expanded on the button.

Solves [ADA-103](https://kaltura.atlassian.net/browse/ADA-103)

[ADA-103]: https://kaltura.atlassian.net/browse/ADA-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ