### PR TITLE
fix(FEC-13775): transcript shows only current caption line

### DIFF
--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -156,7 +156,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
 
   private _addCaptionData = (newData: CuePointData[], captionKey: string) => {
     this._activeCaptionMapId = this._getCaptionMapId();
-    // need to set the captions data to the correct language, and not to the active language.
+    // set the captions data according to the captionKey param
     this._captionMap.set(captionKey, this._sanitizeCaptions(newData));
     this._isLoading = false;
     clearTimeout(this._loadingTimeoutId);

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -156,8 +156,10 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
 
   private _addCaptionData = (newData: CuePointData[], captionKey: string) => {
     this._activeCaptionMapId = this._getCaptionMapId();
+    const oldData = this._captionMap.get(captionKey);
+    const newSanitizedData = this._sanitizeCaptions(newData);
     // set the captions data according to the captionKey param
-    this._captionMap.set(captionKey, this._sanitizeCaptions(newData));
+    this._captionMap.set(captionKey, oldData ? [...oldData, ...newSanitizedData] : newSanitizedData);
     this._isLoading = false;
     clearTimeout(this._loadingTimeoutId);
     this._updateTranscriptPanel();

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -129,7 +129,10 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
       }
     });
     if (captionData.length) {
-      this._addCaptionData(captionData);
+      // take metadata from the first caption, as all captions in captionData have the same language and label
+      const captionMetadata = payload.cues[0].metadata;
+      const captionKey = this._makeCaptionKey(captionMetadata.language, captionMetadata.label);
+      this._addCaptionData(captionData, captionKey);
       this._addTranscriptItem();
     }
   };
@@ -151,9 +154,10 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
     this._updateTranscriptPanel();
   };
 
-  private _addCaptionData = (newData: CuePointData[]) => {
+  private _addCaptionData = (newData: CuePointData[], captionKey: string) => {
     this._activeCaptionMapId = this._getCaptionMapId();
-    this._captionMap.set(this._activeCaptionMapId, this._sanitizeCaptions(newData));
+    // need to set the captions data to the correct language, and not to the active language.
+    this._captionMap.set(captionKey, this._sanitizeCaptions(newData));
     this._isLoading = false;
     clearTimeout(this._loadingTimeoutId);
     this._updateTranscriptPanel();
@@ -168,9 +172,13 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
     const activeTextTrack = allTextTracks.find(track => track.active);
     if (activeTextTrack?.language === 'off') {
       // use 1st captions from text-track list
-      return `${allTextTracks[0]?.language}-${allTextTracks[0]?.label}`;
+      return this._makeCaptionKey(allTextTracks[0]?.language, allTextTracks[0]?.label);
     }
-    return `${activeTextTrack?.language}-${activeTextTrack?.label}`;
+    return this._makeCaptionKey(activeTextTrack?.language, activeTextTrack?.label);
+  };
+
+  private _makeCaptionKey = (language?: string, label?: string): string => {
+    return `${language}-${label}`;
   };
 
   private _activatePlugin = (isFirstOpen = false) => {


### PR DESCRIPTION
**the issue:**
when `preventSeek` is active, transcript should be able to receive new captions in chunks.

**solution:**
- when receiving new captions, create the proper `captionKey`
- pass `captionKey` to `addCaptionData` function
- in `addCaptionData` set the new captions in the map according to the `captionKey` param, and not according to the `activeCaptionKey`
- extract the making of `captionKey` to a function so it will be determined in one place

**related PR:** https://github.com/kaltura/playkit-js-kaltura-cuepoints/pull/66

Solves FEC-13775