### PR TITLE
fix(FEC-13857): search is cleared when prevent seek is enabled

### DIFF
--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -56,6 +56,7 @@ export interface TranscriptProps {
   smallScreen?: boolean;
   expandMode?: string;
   dispatcher: (name: string, payload?: any) => void;
+  activeCaption: string;
 }
 
 interface TranscriptState {
@@ -107,13 +108,15 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
   };
 
   componentDidUpdate(previousProps: Readonly<TranscriptProps>, previousState: Readonly<TranscriptState>): void {
-    const {captions} = this.props;
+    const {captions, activeCaption} = this.props;
     const {search} = this.state;
     if (previousProps.captions !== captions) {
-      this.setState({search: '', isAutoScrollEnabled: true});
+      // clear search value only if active caption language was switched, otherwise keep previous value
+      this.setState({search: previousProps.activeCaption !== activeCaption ? '' : previousState.search, isAutoScrollEnabled: true});
     }
 
-    if (previousState.search !== search) {
+    if (previousState.search !== search || (previousProps.captions !== captions && previousProps.activeCaption === activeCaption)) {
+      // trigger search in case search value has changed, or new captions were added for the same language (preventSeek use-case)
       this._debounced.findSearchMatches();
     }
 

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -271,6 +271,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
             printDisabled={getConfigValue(printDisabled, isBoolean, false)}
             onPrint={this._handlePrint}
             dispatcher={(eventType, payload) => this.dispatchEvent(eventType, payload)}
+            activeCaption={this._activeCaptionMapId}
           /> as any
         );
       },


### PR DESCRIPTION
**the issue:**
if searching for a text in transcript and new captions arrived, the search value is being cleared.
only reproduced when `preventSeek` feature is enabled.

**root cause:**
when `preventSeek` feature is enabled, the transcript is receiving new (current) captions from the cue-point service, which causing to re-render the transcript including the search bar.

**solution:**
- add a new prop which states the active caption language
- clear the search value only if the active caption language has changed
- Also, trigger the search when new captions were added to the transcript for the same language (in order to have results also for the new captions)

Solves FEC-13857