### PR TITLE
fix(FEC-13889): Download_close being reported too many times to application events

### DIFF
--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -278,7 +278,6 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
       presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live, ReservedPresetNames.Ads],
       position: position,
       expandMode: expandMode === SidePanelModes.ALONGSIDE ? SidePanelModes.ALONGSIDE : SidePanelModes.OVER,
-      onDeactivate: this._deactivatePlugin
     }) as number;
     const translates = {
       showTranscript: <Text id="transcript.show_plugin">Show Transcript</Text>,


### PR DESCRIPTION
### Resolves: FEC-13889

**issue**:  

**issue**:  the `_deactiveItem()` (which in turn calls `this.dispatchEvent(TranscriptEvents.TRANSCRIPT_CLOSE`)) is called twice , **one**: on close icon click, **second**: as a callback from onDeactivate() parm of sidePanels() API 

**solution**:  remove the callback, which is redundant since the `_deactiveItem()` is called manualy every time...

#### Related PRs:
https://github.com/kaltura/playkit-js-navigation/pull/360
https://github.com/kaltura/playkit-js-qna/pull/342
https://github.com/kaltura/playkit-js-ui-managers/pull/52