### PR TITLE
fix(FEC-13981): move detach in 3 dots menu

### DIFF
--- a/cypress/e2e/transcript.cy.ts
+++ b/cypress/e2e/transcript.cy.ts
@@ -299,5 +299,16 @@ describe('Transcript plugin', () => {
         cy.get(`[data-testid="transcriptDetachAttachButton"]`).should('not.exist');
       });
     });
+
+    it('should render detach button in transcript menu', () => {
+      mockKalturaBe();
+      loadPlayer().then(() => {
+        cy.get(`[data-testid="popover-anchor-container"]`).should('exist');
+        cy.get(`[data-testid="popover-anchor-container"]`).click();
+        cy.get(`[data-testid="transcript-detach-attach-button"]`).should('not.exist');
+        cy.viewport(726, 380);
+        cy.get(`[data-testid="transcript-detach-attach-button"]`).should('exist');
+      });
+    });
   });
 });

--- a/src/components/transcript-menu/transcript-menu.tsx
+++ b/src/components/transcript-menu/transcript-menu.tsx
@@ -13,6 +13,12 @@ interface TranscriptMenuProps {
   downloadDisabled?: boolean;
   printDisabled?: boolean;
   isLoading?: boolean;
+  detachMenuItem?: {
+    testId: string;
+    label: string;
+    onClick: () => void;
+    isDisabled: boolean;
+  } | null;
 }
 
 interface TranscriptMenuState {
@@ -26,11 +32,14 @@ const translates = {
 
 @withText(translates)
 class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState> {
-  constructor(props: TranscriptMenuProps) {
-    super();
-
-    const {downloadDisabled, onDownload, printDisabled, onPrint, printTranscript, downloadTranscript, isLoading} = props;
+  render() {
+    const {downloadDisabled, onDownload, printDisabled, onPrint, printTranscript, downloadTranscript, isLoading, detachMenuItem} = this.props;
     const items = [];
+
+    if (detachMenuItem) {
+      items.push(detachMenuItem);
+    }
+
     if (!downloadDisabled) {
       items.push({
         testId: 'download-menu-item',
@@ -49,12 +58,8 @@ class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState>
       });
     }
 
-    this.state = {items};
-  }
-
-  render() {
-    return this.state.items.length ? (
-      <PopoverMenu items={this.state.items}>
+    return items.length ? (
+      <PopoverMenu items={items}>
         <Button type={ButtonType.borderless} icon={'more'} tabIndex={-1} />
       </PopoverMenu>
     ) : null;

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -272,7 +272,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
       detachMenuItem = {
         label: kitchenSinkDetached ? attachTranscript : detachTranscript,
         onClick: kitchenSinkDetached ? onAttach : onDetach,
-        testId: 'transcriptDetachAttachButton',
+        testId: 'transcript-detach-attach-button',
         disabled: isLoading
       };
     }


### PR DESCRIPTION
1. Use `ResizeObserver` to handle size of transcript plugin
2. Move detach button into transcript menu if plugin size <= 240px

<img width="823" alt="Screenshot 2024-06-05 at 17 17 16" src="https://github.com/kaltura/playkit-js-transcript/assets/51074448/8ed5423d-a675-4b04-ab5c-1f841a1e5691">


Resolves: https://kaltura.atlassian.net/browse/FEC-13981