### PR TITLE
fix(FEC-14004): add focus styles

### DIFF
--- a/src/components/transcript/transcript.scss
+++ b/src/components/transcript/transcript.scss
@@ -44,6 +44,10 @@
     font-family: sans-serif;
     font-style: normal;
   }
+
+  *:focus-visible:not(input) {
+    outline: 1px solid $tab-focus-color;
+  }
 }
 
 .global-container {

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -153,7 +153,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
     }
   }
 
-  componentWillMount(): void {
+  componentWillUnmount(): void {
     if (this._resizeObserver) {
       this._resizeObserver?.disconnect();
       this._resizeObserver = null;

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -181,7 +181,8 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
   };
 
   private _makeCaptionKey = (language?: string, label?: string): string => {
-    return `${language}-${label}`;
+    // use 'default' language as fallback when language argument is undefined or empty string
+    return `${language || 'default'}-${label}`;
   };
 
   private _activatePlugin = (isFirstOpen = false) => {


### PR DESCRIPTION
1. fix focus styles inside detach window
2. disconnect resize handler on `componentWillUnmount`
3. fix issue with Safari, when caption language firstly `undefined` then `""` (empty string)

Resolves: https://kaltura.atlassian.net/browse/FEC-14004