### PR TITLE
fix(ADA-597): EBSCO (ADA) Transcript - each line is read as a button

### DIFF
--- a/cypress/e2e/transcript.cy.ts
+++ b/cypress/e2e/transcript.cy.ts
@@ -77,7 +77,7 @@ describe('Transcript plugin', () => {
     it('should sanitize html tags', () => {
       mockKalturaBe();
       loadPlayer({showTime: false}).then(() => {
-        cy.get('[aria-label="Dark Side."]').should('have.text', 'Dark Side.');
+        cy.get('[aria-label="Dark Side. Jump to this point in video"]').should('have.text', 'Dark Side.');
       });
     });
   });

--- a/src/components/caption/caption.tsx
+++ b/src/components/caption/caption.tsx
@@ -4,12 +4,17 @@ import {secondsToTime} from '../../utils';
 import {CuePointData} from '../../types';
 import * as styles from './caption.scss';
 
+const {withText, Text} = KalturaPlayer.ui.preacti18n;
+
+
 export interface CaptionProps {
   showTime: boolean;
   searchLength: number;
   scrollTo(el: HTMLElement): void;
   scrollToSearchMatch(el: HTMLElement): void;
   videoDuration: number;
+  captionLabel?: string;
+
 }
 
 interface ExtendedCaptionProps extends CaptionProps {
@@ -24,6 +29,11 @@ interface ExtendedCaptionProps extends CaptionProps {
   isAutoScrollEnabled: boolean;
 }
 
+const translates = {
+  captionLabel: <Text id="transcript.caption_label">Jump to this point in video</Text>
+};
+
+@withText(translates)
 export class Caption extends Component<ExtendedCaptionProps> {
   private _hotspotRef: HTMLElement | null = null;
 
@@ -107,7 +117,7 @@ export class Caption extends Component<ExtendedCaptionProps> {
     const captionA11yProps: Record<string, any> = {
       ariaCurrent: isHighlighted,
       tabIndex: 0,
-      ariaLabel: `${time}${showTime ? ' ' : ''}${caption.text}`,
+      ariaLabel: `${time}${showTime ? ' ' : ''}${caption.text} ${this.props.captionLabel}`,
       role: 'button'
     };
 

--- a/src/components/caption/caption.tsx
+++ b/src/components/caption/caption.tsx
@@ -6,7 +6,6 @@ import * as styles from './caption.scss';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
 
-
 export interface CaptionProps {
   showTime: boolean;
   searchLength: number;
@@ -14,7 +13,6 @@ export interface CaptionProps {
   scrollToSearchMatch(el: HTMLElement): void;
   videoDuration: number;
   captionLabel?: string;
-
 }
 
 interface ExtendedCaptionProps extends CaptionProps {

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -21,7 +21,8 @@
       "attachTranscriptButton": "Bring it back",
       "attachTranscript": "Bring Transcript back",
       "detachTranscript": "Popout Transcript",
-      "transcript": "Transcript"
+      "transcript": "Transcript",
+      "caption_label": "Jump to this point in video"
     }
   }
 }


### PR DESCRIPTION
**Issue:**
Each line in the transcript is read as a button but there is no explanation why it's a button

**Fix:**
Adding additional explanation on in the aria-label

solves [ADA-597](https://kaltura.atlassian.net/browse/ADA-597)


[ADA-597]: https://kaltura.atlassian.net/browse/ADA-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ