### PR TITLE
fix(ADA-1064): Transcript search results inaccessible to screen reader followup from ADA-16

### DIFF
--- a/src/components/caption-list/captionList.tsx
+++ b/src/components/caption-list/captionList.tsx
@@ -1,4 +1,4 @@
-import {h, Component, RefObject} from 'preact';
+import {h, Component} from 'preact';
 import {HOUR} from '../../utils';
 import {Caption} from '../caption';
 import * as styles from './captionList.scss';
@@ -32,8 +32,6 @@ export interface Props {
   activeSearchIndex: number;
   searchMap: Record<string, Record<string, number>>;
   captionProps: CaptionProps;
-  isTranscriptNavigateTriggered: RefObject<boolean>;
-  // isTranscriptNavigateTriggered: boolean;
   eventManager?: any;
   player?: any;
 }
@@ -45,18 +43,17 @@ export class CaptionList extends Component<Props> {
   private _currentCaptionRef: any = null;
   private _firstCaptionRef: any = null;
   private _lastCaptionRef: any = null;
-  // private _isClick: boolean = this.props.isTranscriptNavigateTriggered;
+  private _isTranscriptNavigateTriggered: boolean = false;
 
   constructor(props: Props | undefined) {
     super(props);
     this._setFocus();
-
   }
 
   shouldComponentUpdate(nextProps: Readonly<Props>) {
     const {highlightedMap, data, searchMap, activeSearchIndex, isAutoScrollEnabled} = this.props;
     if (searchMap !== nextProps.searchMap){
-      this.props.isTranscriptNavigateTriggered.current = false;
+      this._isTranscriptNavigateTriggered = false;
     }
     if (
       highlightedMap !== nextProps.highlightedMap ||
@@ -127,7 +124,7 @@ export class CaptionList extends Component<Props> {
 
   private _setFocus = () =>{
     this.props.eventManager?.listen(this.props.player, TranscriptEvents.TRANSCRIPT_NAVIGATE_RESULT, () => {
-      this.props.isTranscriptNavigateTriggered.current = true
+      this._isTranscriptNavigateTriggered = true
     });
   }
 
@@ -154,7 +151,7 @@ export class CaptionList extends Component<Props> {
                     }
                   });
                 }
-                if (this.props.isTranscriptNavigateTriggered.current && isSearchCaption){
+                if (this._isTranscriptNavigateTriggered && isSearchCaption){
                   this._currentCaptionRef?.base?.focus();
                 }
                 if (!isSearchCaption && captionProps.highlighted[captionData.id]) {

--- a/src/components/transcript/transcript.scss
+++ b/src/components/transcript/transcript.scss
@@ -45,7 +45,7 @@
     font-style: normal;
   }
 
-  *:focus-visible:not(input) {
+  *:focus:not(input) {
     outline: 1px solid $tab-focus-color;
   }
 }

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -1,4 +1,4 @@
-import {h, Component, createRef, RefObject} from 'preact';
+import {h, Component} from 'preact';
 import {ui} from '@playkit-js/kaltura-player-js';
 import {debounce} from '../../utils';
 import * as styles from './transcript.scss';
@@ -107,7 +107,6 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
   private _preventScrollEvent: boolean = false;
   private _scrollToSearchMatchEnabled: boolean = false;
   private _widgetRootRef: HTMLElement | null = null;
-  private _isTranscriptNavigateTriggered: RefObject<boolean> = createRef();
 
   private _widgetHeight: number = 0;
   private _topAutoscrollEdge: number = 0;
@@ -133,7 +132,6 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
       // use player size to define transcript root element size
       this._setWidgetSize();
     }
-    this._isTranscriptNavigateTriggered.current = false;
   }
 
   componentDidUpdate(previousProps: Readonly<TranscriptProps>, previousState: Readonly<TranscriptState>): void {
@@ -408,7 +406,6 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
         widgetWidth={this.state.widgetWidth}
         showItemsIcons={true}
         searchActive={false}
-        isTranscriptNavigateTriggered={this._isTranscriptNavigateTriggered}
       />
     );
   };

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -1,4 +1,4 @@
-import {h, Component} from 'preact';
+import {h, Component, createRef, RefObject} from 'preact';
 import {ui} from '@playkit-js/kaltura-player-js';
 import {debounce} from '../../utils';
 import * as styles from './transcript.scss';
@@ -107,6 +107,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
   private _preventScrollEvent: boolean = false;
   private _scrollToSearchMatchEnabled: boolean = false;
   private _widgetRootRef: HTMLElement | null = null;
+  private _isTranscriptNavigateTriggered: RefObject<boolean> = createRef();
 
   private _widgetHeight: number = 0;
   private _topAutoscrollEdge: number = 0;
@@ -132,6 +133,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
       // use player size to define transcript root element size
       this._setWidgetSize();
     }
+    this._isTranscriptNavigateTriggered.current = false;
   }
 
   componentDidUpdate(previousProps: Readonly<TranscriptProps>, previousState: Readonly<TranscriptState>): void {
@@ -406,6 +408,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
         widgetWidth={this.state.widgetWidth}
         showItemsIcons={true}
         searchActive={false}
+        isTranscriptNavigateTriggered={this._isTranscriptNavigateTriggered}
       />
     );
   };


### PR DESCRIPTION
**Issue:**
When user pick an instance of the search result, there is no quick mechanism to get to the line in the transcript with the word from the search box.

**Solution:**
Move the focus to the current line from the search result

Solves [ADA-1064](https://kaltura.atlassian.net/browse/ADA-1064)

[ADA-1064]: https://kaltura.atlassian.net/browse/ADA-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ