### PR TITLE
fix(ADA-1689): [Strategic Blue / University of Sheffield] - highlight search text within the video

### DIFF
--- a/src/components/caption/caption.scss
+++ b/src/components/caption/caption.scss
@@ -58,7 +58,7 @@
       }
     }
     .highlight-search {
-      color: $secondary-text-contrast-color;
+      color: $tone-8-color;
       background-color: $secondary-color;
       border-radius: 2px;
       &::selection {


### PR DESCRIPTION
**Issue:**
when you search in the text box, the strings that match to the search text have orange background and the text is white. it doesn't have good contrast

**Fix:**
change text color to black

solves [ADA-1689](https://kaltura.atlassian.net/browse/ADA-1689)

[ADA-1689]: https://kaltura.atlassian.net/browse/ADA-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ