### PR TITLE
fix(ADA-1777): University of Illinois Urbana-Champaign (ADA) V7 player issues Priority 2(#8) transcript panel does not immediately follow the toggle button

### DIFF
--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -24,6 +24,7 @@ export const PluginButton = ({isActive, label, id, icon, dataTestId, setRef}: Pl
               setRef(node);
             }
           }}
+          tabIndex={0}
           type="button"
           aria-label={label}
           className={[ui.style.upperBarIcon, styles.pluginButton, isActive ? styles.active : ''].join(' ')}

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,6 +1,7 @@
 import {h, Component} from 'preact';
 import {InputField} from '@playkit-js/common/dist/components/input-field';
 import {core} from '@playkit-js/kaltura-player-js';
+import {UpperBarManager} from "@playkit-js/ui-managers";
 
 const {Utils} = core;
 const {withEventManager} = KalturaPlayer.ui.Event;
@@ -40,6 +41,7 @@ export interface SearchProps {
   prevMatchLabel?: string;
   searchResultsLabel?: string;
   eventManager?: any;
+  upperBarManager?: UpperBarManager | undefined;
 }
 
 @withEventManager
@@ -53,12 +55,9 @@ class SearchComponent extends Component<SearchProps> {
 
   private handleKeydownEvent = (event: KeyboardEvent) => {
     if (event.keyCode === TAB && event.shiftKey && this._inputField?.base?.contains(document.activeElement)){
-      let pluginButton = Utils.Dom.getElementBySelector('[data-testid="transcript_pluginButton"]') as HTMLButtonElement;
-      if (!pluginButton){
-        pluginButton = Utils.Dom.getElementBySelector('.playkit-more-icon_fR') as HTMLButtonElement;
-      }
       event.preventDefault();
-      pluginButton.focus();
+      //@ts-ignore
+      this.props.upperBarManager?.focusPluginButton('Transcript');
     }
   };
 

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,7 +1,6 @@
 import {h, Component} from 'preact';
 import {InputField} from '@playkit-js/common/dist/components/input-field';
 import {core} from '@playkit-js/kaltura-player-js';
-import {UpperBarManager} from "@playkit-js/ui-managers";
 
 const {Utils} = core;
 const {withEventManager} = KalturaPlayer.ui.Event;
@@ -40,9 +39,8 @@ export interface SearchProps {
   nextMatchLabel?: string;
   prevMatchLabel?: string;
   searchResultsLabel?: string;
-  eventManager?: any;
-  upperBarManager?: UpperBarManager | undefined;
-  transcriptIconId: number;
+  eventManager?: any
+  focusPluginButton: () => void;
 }
 
 @withEventManager
@@ -57,8 +55,7 @@ class SearchComponent extends Component<SearchProps> {
   private handleKeydownEvent = (event: KeyboardEvent) => {
     if (event.keyCode === TAB && event.shiftKey && this._inputField?.base?.contains(document.activeElement)){
       event.preventDefault();
-      //@ts-ignore
-      this.props.upperBarManager?.focusPluginButton(this.props.transcriptIconId);
+      this.props.focusPluginButton();
     }
   };
 

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -42,6 +42,7 @@ export interface SearchProps {
   searchResultsLabel?: string;
   eventManager?: any;
   upperBarManager?: UpperBarManager | undefined;
+  transcriptIconId: number;
 }
 
 @withEventManager
@@ -57,7 +58,7 @@ class SearchComponent extends Component<SearchProps> {
     if (event.keyCode === TAB && event.shiftKey && this._inputField?.base?.contains(document.activeElement)){
       event.preventDefault();
       //@ts-ignore
-      this.props.upperBarManager?.focusPluginButton('Transcript');
+      this.props.upperBarManager?.focusPluginButton(this.props.transcriptIconId);
     }
   };
 

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,7 +1,12 @@
 import {h, Component} from 'preact';
 import {InputField} from '@playkit-js/common/dist/components/input-field';
+import {core} from '@playkit-js/kaltura-player-js';
 
+const {Utils} = core;
+const {withEventManager} = KalturaPlayer.ui.Event;
+const {TAB} = KalturaPlayer.ui.utils.KeyMap;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
+
 const translates = ({activeSearchIndex, totalSearchResults}: SearchProps) => ({
   searchLabel: <Text id="transcript.search">Search in Transcript</Text>,
   clearSearchLabel: <Text id="transcript.clear_search">Clear search</Text>,
@@ -34,10 +39,28 @@ export interface SearchProps {
   nextMatchLabel?: string;
   prevMatchLabel?: string;
   searchResultsLabel?: string;
+  eventManager?: any;
 }
 
+@withEventManager
 class SearchComponent extends Component<SearchProps> {
   private _inputField: InputField | null = null;
+
+  constructor(props: SearchProps) {
+    super(props);
+    this.props.eventManager?.listen(document, 'keydown', this.handleKeydownEvent);
+  }
+
+  private handleKeydownEvent = (event: KeyboardEvent) => {
+    if (event.keyCode === TAB && event.shiftKey && this._inputField?.base?.contains(document.activeElement)){
+      let pluginButton = Utils.Dom.getElementBySelector('[data-testid="transcript_pluginButton"]') as HTMLButtonElement;
+      if (!pluginButton){
+        pluginButton = Utils.Dom.getElementBySelector('.playkit-more-icon_fR') as HTMLButtonElement;
+      }
+      event.preventDefault();
+      pluginButton.focus();
+    }
+  };
 
   shouldComponentUpdate(nextProps: Readonly<SearchProps>) {
     const {value, activeSearchIndex, totalSearchResults, kitchenSinkActive} = this.props;

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -72,6 +72,7 @@ export interface TranscriptProps {
   playerWidth?: number;
   onJumpToSearchMatch: () => void;
   upperBarManager: UpperBarManager | undefined;
+  transcriptIconId: number;
 }
 
 interface TranscriptState {
@@ -328,6 +329,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
           toggledWithEnter={toggledWithEnter}
           kitchenSinkActive={kitchenSinkActive}
           upperBarManager={this.props.upperBarManager}
+          transcriptIconId={this.props.transcriptIconId}
         />
         {this._renderJumpToSearchButton()}
         <TranscriptMenu {...{downloadDisabled, onDownload, printDisabled, onPrint, isLoading, detachMenuItem, kitchenSinkDetached}} />

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -14,6 +14,7 @@ import {Button, ButtonType, ButtonSize} from '@playkit-js/common/dist/components
 import {ScreenReaderProvider} from '@playkit-js/common/dist/hoc/sr-wrapper';
 import {OnClickEvent, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {TranscriptEvents} from '../../events/events';
+import {UpperBarManager} from "@playkit-js/ui-managers";
 
 const {ENTER, SPACE, TAB} = ui.utils.KeyMap;
 const {withText, Text} = ui.preacti18n;
@@ -70,6 +71,7 @@ export interface TranscriptProps {
   isMobile?: boolean;
   playerWidth?: number;
   onJumpToSearchMatch: () => void;
+  upperBarManager: UpperBarManager | undefined;
 }
 
 interface TranscriptState {
@@ -325,6 +327,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
           totalSearchResults={totalSearchResults}
           toggledWithEnter={toggledWithEnter}
           kitchenSinkActive={kitchenSinkActive}
+          upperBarManager={this.props.upperBarManager}
         />
         {this._renderJumpToSearchButton()}
         <TranscriptMenu {...{downloadDisabled, onDownload, printDisabled, onPrint, isLoading, detachMenuItem, kitchenSinkDetached}} />

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -14,7 +14,6 @@ import {Button, ButtonType, ButtonSize} from '@playkit-js/common/dist/components
 import {ScreenReaderProvider} from '@playkit-js/common/dist/hoc/sr-wrapper';
 import {OnClickEvent, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {TranscriptEvents} from '../../events/events';
-import {UpperBarManager} from "@playkit-js/ui-managers";
 
 const {ENTER, SPACE, TAB} = ui.utils.KeyMap;
 const {withText, Text} = ui.preacti18n;
@@ -71,8 +70,7 @@ export interface TranscriptProps {
   isMobile?: boolean;
   playerWidth?: number;
   onJumpToSearchMatch: () => void;
-  upperBarManager: UpperBarManager | undefined;
-  transcriptIconId: number;
+  focusPluginButton: () => void;
 }
 
 interface TranscriptState {
@@ -328,8 +326,7 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
           totalSearchResults={totalSearchResults}
           toggledWithEnter={toggledWithEnter}
           kitchenSinkActive={kitchenSinkActive}
-          upperBarManager={this.props.upperBarManager}
-          transcriptIconId={this.props.transcriptIconId}
+          focusPluginButton={this.props.focusPluginButton}
         />
         {this._renderJumpToSearchButton()}
         <TranscriptMenu {...{downloadDisabled, onDownload, printDisabled, onPrint, isLoading, detachMenuItem, kitchenSinkDetached}} />

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -335,6 +335,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
               this._handleAttach(CloseDetachTypes.arrow);
             }}
             onJumpToSearchMatch={this._toSearchMatch}
+            upperBarManager={this.upperBarManager}
           />
         ) as any;
       },

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -336,6 +336,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
             }}
             onJumpToSearchMatch={this._toSearchMatch}
             upperBarManager={this.upperBarManager}
+            transcriptIconId={this._transcriptIcon}
           />
         ) as any;
       },

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -335,8 +335,8 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
               this._handleAttach(CloseDetachTypes.arrow);
             }}
             onJumpToSearchMatch={this._toSearchMatch}
-            upperBarManager={this.upperBarManager}
-            transcriptIconId={this._transcriptIcon}
+            //@ts-ignore
+            focusPluginButton={() => this.upperBarManager!.focusPluginButton(this._transcriptIcon)}
           />
         ) as any;
       },


### PR DESCRIPTION
**Issue:**
When user press shift+tab inside transcript plugin after first element - search input, focus move to last element in bottom bar and not to transcript button.

**Fix:**
Add listener to search input so we user focus on it and press shift tab focus will move to transcript button or to more button (if transcript inside more dropdown)

Solves [ADA-1777](https://kaltura.atlassian.net/browse/ADA-1777) 

[ADA-1777]: https://kaltura.atlassian.net/browse/ADA-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ