### PR TITLE
fix(FEC-14235): Player v7 | Transcript | Navigate order with Shift+tab from search result arrows is off.

### DIFF
--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -53,7 +53,7 @@ class SearchComponent extends Component<SearchProps> {
   }
 
   private handleKeydownEvent = (event: KeyboardEvent) => {
-    if (event.keyCode === TAB && event.shiftKey && this._inputField?.base?.contains(document.activeElement)){
+    if (event.keyCode === TAB && event.shiftKey && document.activeElement === this._inputField?.base?.childNodes[0]){
       event.preventDefault();
       this.props.focusPluginButton();
     }


### PR DESCRIPTION
Issue:
When focusing with tab on arrow buttons or x button (inside input filed), shift+tab will move the focus to plugin button instead of the previous element.

Fix:
Move the focus to plugin button only if the activeElement is the first element in the input filed.

Solves [FEC-14235](https://kaltura.atlassian.net/browse/FEC-14235)

[FEC-14235]: https://kaltura.atlassian.net/browse/FEC-14235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ