### PR TITLE
fix(ADA-1777): University of Illinois Urbana-Champaign (ADA) V7 player issues Priority 2(#8) transcript panel does not immediately follow the toggle button

### DIFF
--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -41,7 +41,7 @@ export interface SearchProps {
   prevMatchLabel?: string;
   searchResultsLabel?: string;
   eventManager?: any
-  focusPluginButton: () => void;
+  focusPluginButton: (event: KeyboardEvent) => void;
   player?: any;
 }
 
@@ -52,15 +52,13 @@ class SearchComponent extends Component<SearchProps> {
 
   constructor(props: SearchProps) {
     super(props);
-    this.props.eventManager?.listen(this.props.player, this.props.player.Event.FIRST_PLAY, () => {
-      this.props.eventManager?.listen(document, 'keydown', this.handleKeydownEvent);
-    })
+    this.props.eventManager?.listen(document, 'keydown', this.handleKeydownEvent);
   }
 
   private handleKeydownEvent = (event: KeyboardEvent) => {
     if (event.keyCode === TAB && event.shiftKey && document.activeElement === this._inputField?.base?.childNodes[0]){
-      event.preventDefault();
-      this.props.focusPluginButton();
+      //@ts-ignore
+      this.props.focusPluginButton(event);
     }
   };
 

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -52,7 +52,13 @@ class SearchComponent extends Component<SearchProps> {
 
   constructor(props: SearchProps) {
     super(props);
-    this.props.eventManager?.listen(document, 'keydown', this.handleKeydownEvent);
+    if (this.props.player._firstPlay){
+      this.props.eventManager?.listen(this.props.player, this.props.player.Event.FIRST_PLAY, () => {
+        this.props.eventManager?.listen(document, 'keydown', this.handleKeydownEvent);
+      })
+    } else {
+      this.props.eventManager?.listen(document, 'keydown', this.handleKeydownEvent);
+    }
   }
 
   private handleKeydownEvent = (event: KeyboardEvent) => {

--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -70,7 +70,7 @@ export interface TranscriptProps {
   isMobile?: boolean;
   playerWidth?: number;
   onJumpToSearchMatch: () => void;
-  focusPluginButton: () => void;
+  focusPluginButton: (event: KeyboardEvent) => void;
 }
 
 interface TranscriptState {

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -336,7 +336,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
             }}
             onJumpToSearchMatch={this._toSearchMatch}
             //@ts-ignore
-            focusPluginButton={() => this.upperBarManager!.focusPluginButton(this._transcriptIcon)}
+            focusPluginButton={(event: KeyboardEvent) => this.upperBarManager!.focusPluginButton(this._transcriptIcon, event)}
           />
         ) as any;
       },


### PR DESCRIPTION
1. Sending the event to focusPluginButton function then only in case we have transcript/more button on the dom - we will use event.preventDefault() functionality. so if these elements are not exist on the dom, tab will be moved the previous element as usually. (in case player is too small and top bar buttons are removed)
2. Add the listener to first_play only if this is indeed the first play (before video is played - when preload is enabled) and if the component is called after the first play - listener to keydown is added immediately 

part of - https://github.com/kaltura/playkit-js-ui-managers/pull/68

solves [ADA-1777](https://kaltura.atlassian.net/browse/ADA-1777)

[ADA-1777]: https://kaltura.atlassian.net/browse/ADA-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ