### PR TITLE
fix(ADA-1629): Player v7 | Transcript | "Go to result" button background color doesn't match figma

### DIFF
--- a/src/components/transcript/transcript.scss
+++ b/src/components/transcript/transcript.scss
@@ -84,7 +84,7 @@ $button-height: 32px;
       opacity: 1;
     }
     &[class^="Button__button"]:focus:not([class^="Button__disabled"]) {
-      background-color: $tone-5-color
+      background-color: $tone-6-color
     }
   }
 }

--- a/src/components/transcript/transcript.scss
+++ b/src/components/transcript/transcript.scss
@@ -83,6 +83,9 @@ $button-height: 32px;
     &:focus {
       opacity: 1;
     }
+    &[class^="Button__button"]:focus:not([class^="Button__disabled"]) {
+      background-color: $tone-5-color
+    }
   }
 }
 


### PR DESCRIPTION
Issue:
Background color of "Go to result" button is Tone 5

Fix:
Background color of "Go to result" button has changed to Tone 6.

Solved  [ADA-1629]
(https://kaltura.atlassian.net/browse/ADA-1629)

[ADA-1629]: https://kaltura.atlassian.net/browse/ADA-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ