### PR TITLE
fix(SUP-46969): Transcript menu cut off in V7 player

### DIFF
--- a/src/components/popover-menu/popover-menu.scss
+++ b/src/components/popover-menu/popover-menu.scss
@@ -31,6 +31,9 @@ $child-item-width: 170px;
     position: absolute;
     right: 0px;
     z-index: 1;
+    overflow-y: auto;
+    height: 80px;
+
     &.child-item {
       margin-top: 0;
       top: 0;

--- a/src/components/popover-menu/popover-menu.scss
+++ b/src/components/popover-menu/popover-menu.scss
@@ -31,8 +31,6 @@ $child-item-width: 170px;
     position: absolute;
     right: 0px;
     z-index: 1;
-    overflow-y: auto;
-    height: 80px;
 
     &.child-item {
       margin-top: 0;

--- a/src/components/popover-menu/popover-menu.tsx
+++ b/src/components/popover-menu/popover-menu.tsx
@@ -16,6 +16,8 @@ interface PopoverMenuProps {
   children?: VNode;
   items: Array<PopoverMenuItemData>;
   kitchenSinkDetached: boolean;
+  popOverMenuHeight: number;
+  shouldUseCalculatedHeight: boolean;
 }
 
 interface PopoverMenuState {
@@ -106,7 +108,14 @@ class PopoverMenu extends Component<PopoverMenuProps, PopoverMenuState> {
   };
 
   render() {
-    const {children, items, kitchenSinkDetached} = this.props;
+    const {children, items, kitchenSinkDetached, popOverMenuHeight, shouldUseCalculatedHeight} = this.props;
+
+    let popOverHeight = 0;
+    if (shouldUseCalculatedHeight) {
+      const neededHeight = 48 * items.length;
+      const padding = 14;
+      popOverHeight = popOverMenuHeight - neededHeight <= 0 ? popOverMenuHeight - padding : neededHeight - padding;
+    }
 
     const popoverMenuContent = (
       <div className={styles.popoverContainer}>
@@ -132,6 +141,7 @@ class PopoverMenu extends Component<PopoverMenuProps, PopoverMenuState> {
 
         <div
           className={styles.popoverComponent}
+          style={shouldUseCalculatedHeight ? {height: `${popOverHeight}px`, overflowY: 'auto'} : {}}
           role="menu"
           aria-expanded={this.state.isOpen}
           id="popoverContent"

--- a/src/components/transcript-menu/transcript-menu.tsx
+++ b/src/components/transcript-menu/transcript-menu.tsx
@@ -8,6 +8,8 @@ import {Button, ButtonType} from '@playkit-js/common/dist/components/button';
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
 
 interface TranscriptMenuProps {
+  shouldUseCalculatedHeight: boolean;
+  popOverHeight: number;
   printTranscript?: string;
   downloadTranscript?: string;
   moreOptionsLabel?: string;
@@ -41,6 +43,8 @@ const translates = {
 class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState> {
   render() {
     const {
+      shouldUseCalculatedHeight,
+      popOverHeight,
       downloadDisabled,
       onDownload,
       printDisabled,
@@ -94,7 +98,11 @@ class TranscriptMenu extends Component<TranscriptMenuProps, TranscriptMenuState>
     }
 
     return items.length ? (
-      <PopoverMenu items={items} kitchenSinkDetached={kitchenSinkDetached}>
+      <PopoverMenu
+        items={items}
+        kitchenSinkDetached={kitchenSinkDetached}
+        popOverMenuHeight={popOverHeight}
+        shouldUseCalculatedHeight={shouldUseCalculatedHeight}>
         <Button type={ButtonType.borderless} icon={'more'} tabIndex={-1} ariaLabel={this.props.moreOptionsLabel} />
       </PopoverMenu>
     ) : null;

--- a/src/transcript-plugin.tsx
+++ b/src/transcript-plugin.tsx
@@ -344,6 +344,7 @@ export class TranscriptPlugin extends KalturaPlayer.core.BasePlugin {
             focusPluginButton={(event: KeyboardEvent) => this.upperBarManager!.focusPluginButton(this._transcriptIcon, event)}
             textTracks={this._getTextTracks()}
             changeLanguage={this._changeLanguage}
+            sidePanelPosition={position}
           />
         ) as any;
       },


### PR DESCRIPTION
Issue:
Popover is being cut when side panel is on bottom position by the player.
On fullscreen, the problem is not occur.

Fix:
Add scroll:
In order to add scroll, it is required to add fixed height.
Because the height cannot be fixed due to the fact that that number of items in the popover is dynamic, suppose to calculate the difference between the header and the global container.

solved-https://kaltura.atlassian.net/browse/SUP-46969