### PR TITLE
Revert "Revert "fix(ADA-3422): Assure Resume button exists on focus""

### DIFF
--- a/src/components/transcript/transcript.tsx
+++ b/src/components/transcript/transcript.tsx
@@ -421,7 +421,16 @@ export class Transcript extends Component<TranscriptProps, TranscriptState> {
 
   private _handleClick = (event: MouseEvent | KeyboardEvent) => {
     event.preventDefault();
-    this._autoscrollButtonRef?.focus();
+
+    if (!this.state.isAutoScrollEnabled) {
+      this._autoscrollButtonRef?.focus();
+      return;
+    }
+
+    this.setState(
+      {isAutoScrollEnabled: false},
+      () => this._autoscrollButtonRef?.focus()
+    );
   };
 
   private _handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
Reverts kaltura/playkit-js-transcript#282  because it was merged in code freeze and fixes https://kaltura.atlassian.net/browse/ADA-3422.
This was already approved here https://github.com/kaltura/playkit-js-transcript/pull/280