### PR TITLE
chore: upgrade ui-managers dependency for release 7.264

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@playkit-js/kaltura-player-js": "3.17.56",
     "@playkit-js/playkit-js-ui": "0.79.13",
-    "@playkit-js/ui-managers": "1.6.2-canary.0-9634d47",
+    "@playkit-js/ui-managers": "1.9.0",
     "@types/sanitize-html": "^2.9.3",
     "conventional-github-releaser": "3.1.3",
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
Updates `@playkit-js/ui-managers` from `1.6.2-canary` → `1.9.0`

Release: 7.264